### PR TITLE
Alternative handling of the non-linear time slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
       <div class="row" style="margin-top: 20px">
         <span id="speed-icon" class="glyphicon glyphicon-dashboard" style="font-size: 24pt; vertical-align: middle" data-toggle="tooltip" title="Simulation speed"></span>
         &nbsp;&nbsp;
-        <input id="speed" style="width: 650px"  data-slider-id='speedSlider' type="text" data-slider-min="-4.7" data-slider-max="9.7" data-slider-step=".000001" data-slider-value="0" />
+        <input id="speed" style="width: 650px"  data-slider-id='speedSlider' type="text" data-slider-min="0" data-slider-max="10" data-slider-step=".5" data-slider-value="7" />
       </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -595,12 +595,12 @@ messageModal = function(model, message) {
   m.modal();
 };
 
-var sliderTransform = function(v) {
-  v = Math.pow(v, 3) + 100;
+// Transforms the simulation speed from a linear slider
+// to a logarithmically scaling time factor.
+var speedSliderTransform = function(v) {
+  v = Math.pow(2, v);
   if (v < 1)
     return 1;
-  else if (v > 1000)
-    return 1000;
   else
     return v;
 };
@@ -630,7 +630,7 @@ render.update = function() {
   var step = function(timestamp) {
     if (!playback.isPaused() && last !== null && timestamp - last < 500) {
       var wallMicrosElapsed = (timestamp - last) * 1000;
-      var speed = sliderTransform($('#speed').slider('getValue'));
+      var speed = speedSliderTransform($('#speed').slider('getValue'));
       var modelMicrosElapsed = wallMicrosElapsed / speed;
       var modelMicros = state.current.time + modelMicrosElapsed;
       state.seek(modelMicros);
@@ -727,7 +727,7 @@ var getLeader = function() {
 $("#speed").slider({
   tooltip: 'always',
   formater: function(value) {
-    return '1/' + sliderTransform(value).toFixed(0) + 'x';
+    return '1/' + speedSliderTransform(value).toFixed(0) + 'x';
   },
   reversed: true,
 });

--- a/script.js
+++ b/script.js
@@ -727,7 +727,7 @@ var getLeader = function() {
 $("#speed").slider({
   tooltip: 'always',
   formater: function(value) {
-    return sliderTransform(value).toFixed(0) + 'x';
+    return '1/' + sliderTransform(value).toFixed(0) + 'x';
   },
   reversed: true,
 });


### PR DESCRIPTION
When I started playing with the raftscope visualizer, I found myself a little confused by the time slider. I really enjoyed the project so I tried tweaking it to see if I could make that initial user experience a little more natural feeling.

This change is two parts:

1) a tool tip change to show a 1/x fraction.

2) a non-linear scale change. I was thrown off a bit with how the x^3 scaling makes certain sections of the slider pretty unresponsive and other sections over responsive. A log scaling makes the user experience a little more consistent.
